### PR TITLE
Migrate to MDG

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,6 @@ legacyForge {
       // Recommended logging level for the console
       systemProperty 'forge.logging.console.level', 'debug'
 
-      // For some reason this isn't being added by MDG so we have to open it manually...
-      jvmArguments.addAll '--add-opens', 'java.base/java.lang.invoke=cpw.mods.securejarhandler'
-
       client()
     }
 
@@ -33,9 +30,6 @@ legacyForge {
       systemProperty 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
       // Recommended logging level for the console
       systemProperty 'forge.logging.console.level', 'debug'
-
-      // For some reason this isn't being added by MDG so we have to open it manually...
-      jvmArguments.addAll '--add-opens', 'java.base/java.lang.invoke=cpw.mods.securejarhandler'
 
       server()
     }
@@ -47,9 +41,6 @@ legacyForge {
       systemProperty 'forge.logging.console.level', 'debug'
 
       programArguments.addAll '--mod', 'simple_absorption', '--all', '--output', 'src/generated/resources/'
-
-      // For some reason this isn't being added by MDG so we have to open it manually...
-      jvmArguments.addAll '--add-opens', 'java.base/java.lang.invoke=cpw.mods.securejarhandler'
 
       data()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,10 @@ sourceSets.main.resources.srcDir generateModMetadata
 legacyForge.ideSyncTask generateModMetadata
 
 
+java {
+    withSourcesJar()
+}
+
 // IDEA no longer automatically downloads sources/javadoc jars for dependencies, so we need to explicitly enable the behavior.
 idea {
   module {

--- a/build.gradle
+++ b/build.gradle
@@ -1,175 +1,108 @@
-buildscript {
-  repositories {
-    maven { url = 'https://maven.minecraftforge.net' }
-    jcenter()
-    mavenCentral()
-    maven {
-      name "Parchment"
-      url "https://maven.parchmentmc.org"
-    }
-  }
-  dependencies {
-    classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
-    classpath 'org.parchmentmc:librarian:1.+'
-  }
+plugins {
+  // Apply the plugin. You can find the latest version at https://projects.neoforged.net/neoforged/ModDevGradle
+  id 'net.neoforged.moddev.legacyforge' version '2.0.112'
+  id 'idea'
 }
-apply plugin: 'net.minecraftforge.gradle'
-apply plugin: 'eclipse'
-apply plugin: 'maven-publish'
-apply plugin: 'org.parchmentmc.librarian.forgegradle'
 
 group = "knightminer"
 archivesBaseName = "SimpleAbsorption"
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
+version = "${minecraft_version}-${mod_version}"
 
-// External properties
-ext.configFile = file "build.properties"
-configFile.withReader {
-  // Load config.  It shall from now be referenced as simply config or project.config
-  def prop = new Properties()
-  prop.load(it)
-  project.ext.config = new ConfigSlurper().parse prop
-}
-configurations {
-    deployerJars
-}
+legacyForge {
+  version = "${minecraft_version}-${forge_version}"
 
-version = "${config.minecraft_version}-${config.mod_version}"
+  // Validate AT files and raise errors when they have invalid targets
+  validateAccessTransformers = true
 
-sourceSets {
-  main { resources {
-    srcDirs "$rootDir/src/generated/resources"
-    //But exclude the cache of the generated data from what gets built
-    exclude '.cache'
-  } }
-}
-
-minecraft {
-  mappings channel: 'parchment', version: "${config.parchment_version}-${config.minecraft_version}"
-  accessTransformer project.file("src/main/resources/META-INF/accesstransformer.cfg")
   runs {
     client {
-      workingDirectory project.file('run')
       // Recommended logging data for a userdev environment
-      property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+      systemProperty 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
       // Recommended logging level for the console
-      property 'forge.logging.console.level', 'debug'
-      mods {
-        simple_absorption {
-          source sourceSets.main
-        }
-      }
+      systemProperty 'forge.logging.console.level', 'debug'
+
+      // For some reason this isn't being added by MDG so we have to open it manually...
+      jvmArguments.addAll '--add-opens', 'java.base/java.lang.invoke=cpw.mods.securejarhandler'
+
+      client()
     }
 
     server {
-      workingDirectory project.file('run')
       // Recommended logging data for a userdev environment
-      property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+      systemProperty 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
       // Recommended logging level for the console
-      property 'forge.logging.console.level', 'debug'
-      mods {
-        simple_absorption {
-          source sourceSets.main
-        }
-      }
+      systemProperty 'forge.logging.console.level', 'debug'
+
+      // For some reason this isn't being added by MDG so we have to open it manually...
+      jvmArguments.addAll '--add-opens', 'java.base/java.lang.invoke=cpw.mods.securejarhandler'
+
+      server()
     }
 
     data {
-      workingDirectory project.file('run')
       // Recommended logging data for a userdev environment
-      property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
+      systemProperty 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
       // Recommended logging level for the console
-      property 'forge.logging.console.level', 'debug'
-      args '--mod', 'simple_absorption', '--all', '--output', file('src/generated/resources/')
-      mods {
-        simple_absorption {
-           source sourceSets.main
-        }
-      }
+      systemProperty 'forge.logging.console.level', 'debug'
+
+      programArguments.addAll '--mod', 'simple_absorption', '--all', '--output', 'src/generated/resources/'
+
+      // For some reason this isn't being added by MDG so we have to open it manually...
+      jvmArguments.addAll '--add-opens', 'java.base/java.lang.invoke=cpw.mods.securejarhandler'
+
+      data()
+    }
+  }
+
+  mods {
+    "${mod_id}" {
+      sourceSet sourceSets.main
     }
   }
 }
 
 repositories {
-  // JEI
   maven {
-    name 'DVS1 Maven FS'
+    name 'DVS1 Maven FS' // JEI Maven for 1.19.2 and below
     url 'https://dvs1.progwml6.com/files/maven'
   }
 }
 
 dependencies {
-  minecraft "net.minecraftforge:forge:${config.minecraft_version}-${config.forge_version}"
-    
   // compile against the JEI API but do not include it at runtime
-  compileOnly fg.deobf("mezz.jei:jei-${config.minecraft_version}:${config.jei_version}:api")
+  modCompileOnly "mezz.jei:jei-${minecraft_version}:${jei_version}:api"
   // at runtime, use the full JEI jar
-  runtimeOnly fg.deobf("mezz.jei:jei-${config.minecraft_version}:${config.jei_version}")
+  modRuntimeOnly "mezz.jei:jei-${minecraft_version}:${jei_version}"
 }
 
+// This block of code expands all declared replace properties in the specified resource targets.
+// A missing property will result in an error. Properties are expanded using ${} Groovy notation.
+var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {
+  var replaceProperties = [
+          mod_id            : mod_id,
+          version           : version,
+          minecraft_range   : minecraft_range,
+          forge_range       : forge_range,
+          loader_range      : loader_range
+  ]
+  inputs.properties replaceProperties
+  expand replaceProperties
+  from "src/main/templates"
+  into "build/generated/sources/modMetadata"
+}
 
-// process mods.toml to inject variables
-def modsTomlSpec = copySpec{
-  from(sourceSets.main.resources) {
-    include 'META-INF/mods.toml'
-    expand 'version': config.mod_version,
-            'minecraft_range': config.minecraft_range,
-            'forge_range': config.forge_range
+// Include the output of "generateModMetadata" as an input directory for the build
+// this works with both building through Gradle and the IDE.
+sourceSets.main.resources.srcDir generateModMetadata
+// To avoid having to run "generateModMetadata" manually, make it run on every project reload
+legacyForge.ideSyncTask generateModMetadata
+
+
+// IDEA no longer automatically downloads sources/javadoc jars for dependencies, so we need to explicitly enable the behavior.
+idea {
+  module {
+    downloadSources = true
+    downloadJavadoc = true
   }
-}
-// need to copy into each build directory, unfortunately does not seem easy to do this automatically
-def buildPaths = [
-        "$rootDir/out/production/resources", // IDEA
-        "$rootDir/bin", // Eclipse
-]
-
-// task to add mods.toml to all relevant folders
-task replaceResources {
-  // copy for gradle
-  copy {
-    outputs.upToDateWhen { false }
-    with modsTomlSpec
-    into processResources.destinationDir
-  }
-  // copy for IDEs
-  buildPaths.each { path ->
-    if (new File(path).exists()) {
-      copy {
-        outputs.upToDateWhen { false }
-        with modsTomlSpec
-        into path
-      }
-    }
-  }
-}
-
-processResources {
-  exclude 'META-INF/mods.toml'
-  finalizedBy replaceResources
-}
-
-jar {
-  manifest {
-    attributes([
-      "Specification-Title": "Simple Absorption",
-      "Specification-Vendor": "KnightMiner",
-      "Specification-Version": "1", // We are version 1 of ourselves
-      "Implementation-Title": project.name,
-      "Implementation-Version": "${version}",
-      "Implementation-Vendor": "KnightMiner",
-      "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
-    ])
-  }
-}
-
-jar.finalizedBy('reobfJar')
-
-// because the normal output has been made to be obfuscated
-task sourcesJar(type: Jar) {
-    from sourceSets.main.allJava
-    classifier = 'sources'
-}
-
-artifacts {
-    archives sourcesJar
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,12 @@
 # Mod
+mod_id=simple_absorption
 mod_version=1.3.0
 
 # Dependencies
 minecraft_version=1.18.2
 minecraft_range=[1.18.2,1.19)
 
+loader_range=[33,)
 forge_version=40.1.0
 forge_range=[40.1.0,)
 parchment_version=2022.09.04

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ minecraft_version=1.18.2
 minecraft_range=[1.18.2,1.19)
 
 loader_range=[33,)
-forge_version=40.1.0
-forge_range=[40.1.0,)
+forge_version=40.3.11
+forge_range=[40.3.11,)
 parchment_version=2022.09.04
 
 # Optional Dependencies

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}

--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -1,9 +1,9 @@
 modLoader="javafml"
-loaderVersion="[33,)"
+loaderVersion="${loader_range}"
 issueTrackerURL="https://github.com/KnightMiner/SimpleAbsorption/issues/"
 license="MIT"
 [[mods]]
-modId="simple_absorption"
+modId="${mod_id}"
 version="${version}"
 displayName="Simple Absorption"
 displayURL="https://www.curseforge.com/minecraft/mc-mods/simple-absorption"
@@ -13,13 +13,13 @@ authors="KnightMiner"
 description='''
 Mod adding a simple absorption shield for the player, restored when the hunger bar is full.
 '''
-[[dependencies.simple_absorption]] 
+[[dependencies."${mod_id}"]]
     modId="forge"
     mandatory=true
     versionRange="${forge_range}" #mandatory
     ordering="AFTER"
     side="BOTH"
-[[dependencies.simple_absorption]]
+[[dependencies."${mod_id}"]]
     modId="minecraft"
     mandatory=true
     versionRange="${minecraft_range}"


### PR DESCRIPTION
This also updates Forge and Gradle as MDG wasn't playing nice with the older versions.


MDG is much faster than old Forge Gradle, and will greatly ease the eventual transition to NeoForge.